### PR TITLE
fix syntax error and fixed version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy==1.19.5
 scipy==1.4.1
 sklearn==0.20.3
-numexpr==2.6.9
 fastcluster==1.2.4
 h5py==2.9.0
 onnxruntime==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,8 @@ setup(
     packages=find_packages(),
     url="https://github.com/desh2608/diarizer",
     install_requires=[
-        "numpy==1.22.4",
+        "numpy>=1.19.5",
         "scipy==1.4.1",
-        "numexpr==2.6.9",
         "h5py==2.9.0",
         "fastcluster==1.2.4",
         "onnxruntime==1.4.0",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     packages=find_packages(),
     url="https://github.com/desh2608/diarizer",
     install_requires=[
-        "numpy>=1.19.5",
+        "numpy==1.22.4",
         "scipy==1.4.1",
         "numexpr==2.6.9",
         "h5py==2.9.0",
@@ -85,7 +85,7 @@ setup(
     ],
     dependency_links=[
         "https://github.com/desh2608/scikit-learn/releases/download/v0.24.0-dev-overlap/scikit_learn-0.24.dev0-cp38-cp38-linux_x86_64.whl",
-    ]
+    ],
     license="Apache License, Version 2.0",
     cmdclass={"install": PostInstallCommand, "develop": PostDevelopCommand},
 )


### PR DESCRIPTION
Hi,
 
I add a comma and fixed `numpy` version because if `numpy==1.24.2` then `numexpr` and `dscore` will get error.