### PR TITLE
add utils before cmd for cluster

### DIFF
--- a/path.sh
+++ b/path.sh
@@ -4,4 +4,5 @@ export PYTHONUNBUFFERED=1
 # Activate environment
 . /home/draj/anaconda3/etc/profile.d/conda.sh && conda deactivate && conda activate vbx
 
+export PATH=${PATH}:`pwd`/utils
 export LC_ALL=C


### PR DESCRIPTION
Hello,

I add `utils` before `cmd` code, because the `queue.pl` is in the `utils`.