### PR TITLE
Correct variables and adjust environment.

### DIFF
--- a/path.sh
+++ b/path.sh
@@ -2,7 +2,8 @@
 export PYTHONUNBUFFERED=1
 
 # Activate environment
-. /home/draj/anaconda3/etc/profile.d/conda.sh && conda deactivate && conda activate vbx
+eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
+conda deactivate && conda activate diar
 
 export PATH=${PATH}:`pwd`/utils
 export LC_ALL=C

--- a/scripts/ami/051_vbx_ovl.sh
+++ b/scripts/ami/051_vbx_ovl.sh
@@ -29,7 +29,7 @@ if [ $stage -le 0 ]; then
           --out-rttm-dir $EXP_DIR/$part/vbx_ovl \
           --xvec-ark-file $EXP_DIR/$part/xvec/${filename}.ark \
           --segments-file $EXP_DIR/$part/xvec/${filename}.seg \
-          --overlap-rttm $EXP_DIR/$split/ovl/${filename}.rttm \
+          --overlap-rttm $EXP_DIR/$part/ovl/${filename}.rttm \
           --xvec-transform diarizer/models/ResNet101_16kHz/transform.h5 \
           --plda-file diarizer/models/ResNet101_16kHz/plda \
           --threshold -0.015 \


### PR DESCRIPTION
Hello,

I think that the variable in `051_vbx_ovl.sh` may be wrong.
 
https://github.com/desh2608/diarizer/blob/master/scripts/ami/051_vbx_ovl.sh#L32

The environment used in the README is `diar`, but you used `VBx` in `path.sh`. 

Additionally, since the location of conda may differ for each person, for better compatibility, I suggest using `eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"` instead.